### PR TITLE
Order.pickup_time update - controller test - fix

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+
+  def clean_datetime datetime
+    datetime.to_datetime.strftime("%Y-%m-%d %H:%M:%S")
+  rescue
+    nil
+  end
+
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe ApplicationHelper do
+  it "should exist" do
+    expect(ApplicationHelper.class).to eq Module
+  end
+
+  describe ".clean_datetime" do
+    it "should be present" do
+      ApplicationHelper.methods.include? :clean_datetime
+    end
+
+    it "should convert to propper datetime string format" do
+      [Time.parse("2015-05-17 23:50:32"), "2015-05-17 23:50:32"].each do |datetime|
+        expect( clean_datetime(datetime) ).to eq "2015-05-17 23:50:32"
+      end
+    end
+
+    it "should return nil for wrong datetime inputs" do
+      ["abcd", 12345, "", nil].each do |datetime|
+        expect( clean_datetime(datetime) ).to eq nil
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/order_spec.rb
+++ b/spec/requests/api/v1/order_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ApplicationHelper
 
 describe Api::V1::OrdersController do
 
@@ -84,12 +85,24 @@ describe Api::V1::OrdersController do
     end
 
     it 'changing an pickup_time' do
+      datetime = clean_datetime(Time.zone.now + 2.hours)
+      json_data = { order: {user_id: user.id, pickup_time: datetime},
+                    menu_items: [menu_item.id]
+                  }.to_json
 
-      patch "/v1/orders/#{@order.id}", {order: {user_id: user.id, pickup_time: Time.zone.now + 2.hours}, menu_items: [menu_item.id]}.to_json
-      puts response_json
-      expect(response_json).to eq(
-                                   {'instance'=>{"user"=>user.id, "status"=>"pending", "pickup_time"=> (Time.zone.now + 2.hours).to_datetime , "items"=>[{"id"=>menu_item.id, "item"=>menu_item.name, "price"=>menu_item.price.to_f}]}}
-                               )
+      patch "/v1/orders/#{@order.id}", json_data
+
+      expect( response_json["instance"].except('pickup_time') ).to eq(
+        {
+          "user"=>user.id,
+          "status"=>"pending",
+          "items"=>[{
+            "id"=>menu_item.id,
+            "item"=>menu_item.name,
+            "price"=>menu_item.price.to_f
+          }]
+        })
+      expect( clean_datetime(response_json["instance"]["pickup_time"]) ).to eq datetime
     end
 
   end


### PR DESCRIPTION
- The problem was that after the PATCH the `pickup_time` was in a wrong format. Fixed it by testing `pickup_time` separately.
- Also between running `PATCH` and running `expect` there was a few milliseconds difference. Fixed it by creating a `datetime` variable.
- Added `clean_datetime` helper method that will convert the time in a preferred format.
  I searched online and sweetish standard is: `2015-05-17 23:50:32`
  I suggest we use this method all over the app, every time we need the the datetime in a correct format to avoid confusions.
